### PR TITLE
Escape json reserved characters in property values.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,11 +147,13 @@ project(":core") {
 
 task fixIML {
     def imlFile = file('NotTiled.iml')
-    def iml = new XmlParser().parse(imlFile)
-    iml.component.facet.each { facet ->
-        def type = facet.@type
-        if (type == 'android-gradle' || type == 'java-gradle')
-            facet.parent().remove(facet)
+    if (imlFile.exists()) {
+        def iml = new XmlParser().parse(imlFile)
+        iml.component.facet.each { facet ->
+            def type = facet.@type
+            if (type == 'android-gradle' || type == 'java-gradle')
+                facet.parent().remove(facet)
+        }
+        new XmlNodePrinter(new PrintWriter(new FileWriter(imlFile))).print(iml)
     }
-    new XmlNodePrinter(new PrintWriter(new FileWriter(imlFile))).print(iml)
 }

--- a/core/src/com/mirwanda/nottiled/StringBuilderPlus.java
+++ b/core/src/com/mirwanda/nottiled/StringBuilderPlus.java
@@ -1,5 +1,8 @@
 package com.mirwanda.nottiled;
 
+import com.badlogic.gdx.utils.JsonValue;
+import com.badlogic.gdx.utils.JsonValue.ValueType;
+import com.badlogic.gdx.utils.JsonWriter;
 import com.badlogic.gdx.utils.StringBuilder;
 
 public class StringBuilderPlus extends com.badlogic.gdx.utils.StringBuilder
@@ -43,48 +46,27 @@ public class StringBuilderPlus extends com.badlogic.gdx.utils.StringBuilder
 	}
 	
 	public void wpropj(java.util.List<property> pr){
+		JsonValue properties = new JsonValue(ValueType.array);
 		if (pr.size()>0){
-			wlo("\"properties\":[");
 			for(int i=0;i<pr.size();i++)
 			{
-				wlo("{");
+				JsonValue property = new JsonValue(ValueType.object);
+				properties.addChild(property);
+
 				property p=pr.get(i);
-				wl("\"name\":\""+p.getName()+"\",");
-				if (p.getType()=="")
+				property.addChild("name",new JsonValue(p.getName()));
+
+				if (p.getType().equals(""))
 				{
-					wl("\"type\":\"string\",");
-					
+					property.addChild("type", new JsonValue("string"));
 				}else
 				{
-					wl("\"type\":\""+p.getType()+"\",");
-					
+					property.addChild("type", new JsonValue(p.getType()));
 				}
-				if (p.getType().equalsIgnoreCase("string") || p.getType().equalsIgnoreCase("") )
-				{
-					wl("\"value\":\""+p.getValue()+"\"");
-					
-				}else
-				{
-					wl("\"value\":"+p.getValue()+"");
-					
-				}
-				
-				if (i!=pr.size()-1) 
-				{
-					wlc("},");
-				}else
-				{
-					wlc("}");
-				}
-				
+				property.addChild("type", new JsonValue(p.getValue()));
 			}
-			wlc("]");
-			
 		}
-	else
-	{
-		wl("\"properties\":[]");
-	}
+		wl("\"properties\":"+properties.toJson(JsonWriter.OutputType.json));
 	}
 	
 	public void wl(String s){


### PR DESCRIPTION
This PR fix issue when exported json becomes invalid because object properties contains characters reserved by json, well in my case property value is json itself.

Issue reproducible on this map: 
https://github.com/NYRDS/remixed-dungeon/blob/master/TiledMaps/TestMapCurch.tmx

Also, small fix to top level gradle, so fresh checkout will build in Android Studio as is.